### PR TITLE
keep list names visible while scrolling

### DIFF
--- a/list-manager/src/Manager.css
+++ b/list-manager/src/Manager.css
@@ -54,3 +54,9 @@ div.group {
 .followerTable {
   margin-bottom: 12px;
 }
+
+.followerTable thead {
+  position: sticky;
+  top: 0px;
+  background-color: white;
+}


### PR DESCRIPTION
Hi,

Thanks for this tool. I found it via Mike Masnick's [article](https://www.techdirt.com/2022/12/29/some-tricks-to-making-mastodon-way-more-useful/) in Techdirt.

When I scroll my follower list I lose track of which column is which group because the labels stay at the top of the page. This patch should fix that. Full disclosure, I "tested" it via dev tools by adding style attributes to the `thead` but I haven't really tested it the way it's done in the PR.